### PR TITLE
Remove non-supported arch on external LIBS for speedup build. Fixed cmakefile Examples with DSO unicorn link fail.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build/
+build.dev/
+build.release/
 .cache/
 .idea/
 cmake-build-release/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,24 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -g -rdynamic -O0")
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN 1)
 
+set(UNICORN_ARCH "x86;arm;arm64" CACHE STRING "Build only x86, ARM, and ARM64 for Unicorn")
+
+set(CAPSTONE_X86_SUPPORT ON CACHE BOOL "Enable X86 support in Capstone")
+set(CAPSTONE_ARM_SUPPORT ON CACHE BOOL "Disable ARM support in Capstone")
+set(CAPSTONE_ARM64_SUPPORT ON CACHE BOOL "Disable ARM64 support in Capstone")
+set(CAPSTONE_MIPS_SUPPORT OFF CACHE BOOL "Disable MIPS support in Capstone")
+set(CAPSTONE_PPC_SUPPORT OFF CACHE BOOL "Disable PPC support in Capstone")
+set(CAPSTONE_SPARC_SUPPORT OFF CACHE BOOL "Disable SPARC support in Capstone")
+set(CAPSTONE_SYSZ_SUPPORT OFF CACHE BOOL "Disable SYSZ support in Capstone")
+set(CAPSTONE_XCORE_SUPPORT OFF CACHE BOOL "Disable XCore support in Capstone")
+
+set(KEYSTONE_ARCH "X86;ARM;ARM64" CACHE STRING "Build only X86, ARM, and ARM64 for Keystone")
+
+set(LIEF_PYTHON_API OFF CACHE BOOL "Disable Python bindings for LIEF")
+set(LIEF_DOC OFF CACHE BOOL "Disable LIEF documentation")
+set(LIEF_EXAMPLES OFF CACHE BOOL "Disable LIEF examples")
+set(LIEF_TESTS OFF CACHE BOOL "Disable LIEF tests")
+
 file(GLOB_RECURSE SOURCES "src/*.cpp")
 
 # Copy vdso.bin to build directory to prevent absolute path inclusion

--- a/examples/CpuidHandler/CMakeLists.txt
+++ b/examples/CpuidHandler/CMakeLists.txt
@@ -9,4 +9,5 @@ find_path(ARION_INCLUDE_DIR arion/arion.hpp)
 add_executable(cpuid_handler cpuid_handler.cpp)
 
 target_link_libraries(cpuid_handler PRIVATE ${ARION_LIB})
+target_link_libraries(cpuid_handler PRIVATE unicorn ${UNICORN_LIB})
 target_include_directories(cpuid_handler PRIVATE ${ARION_INCLUDE_DIR}/arion)

--- a/examples/Disassembler/CMakeLists.txt
+++ b/examples/Disassembler/CMakeLists.txt
@@ -9,4 +9,5 @@ find_path(ARION_INCLUDE_DIR arion/arion.hpp)
 add_executable(disassembler disassembler.cpp)
 
 target_link_libraries(disassembler PRIVATE ${ARION_LIB})
+target_link_libraries(cpuid_handler PRIVATE unicorn ${UNICORN_LIB})
 target_include_directories(disassembler PRIVATE ${ARION_INCLUDE_DIR}/arion)

--- a/examples/Disassembler/CMakeLists.txt
+++ b/examples/Disassembler/CMakeLists.txt
@@ -9,5 +9,5 @@ find_path(ARION_INCLUDE_DIR arion/arion.hpp)
 add_executable(disassembler disassembler.cpp)
 
 target_link_libraries(disassembler PRIVATE ${ARION_LIB})
-target_link_libraries(cpuid_handler PRIVATE unicorn ${UNICORN_LIB})
+target_link_libraries(disassembler PRIVATE unicorn ${UNICORN_LIB})
 target_include_directories(disassembler PRIVATE ${ARION_INCLUDE_DIR}/arion)

--- a/examples/ForkHandler/CMakeLists.txt
+++ b/examples/ForkHandler/CMakeLists.txt
@@ -9,7 +9,7 @@ find_path(ARION_INCLUDE_DIR arion/arion.hpp)
 add_executable(fork_handler fork_handler.cpp)
 
 target_link_libraries(fork_handler PRIVATE ${ARION_LIB})
-target_link_libraries(cpuid_handler PRIVATE unicorn ${UNICORN_LIB})
+target_link_libraries(fork_handler PRIVATE unicorn ${UNICORN_LIB})
 target_include_directories(fork_handler PRIVATE ${ARION_INCLUDE_DIR}/arion)
 
 add_executable(target target.c)

--- a/examples/ForkHandler/CMakeLists.txt
+++ b/examples/ForkHandler/CMakeLists.txt
@@ -9,6 +9,7 @@ find_path(ARION_INCLUDE_DIR arion/arion.hpp)
 add_executable(fork_handler fork_handler.cpp)
 
 target_link_libraries(fork_handler PRIVATE ${ARION_LIB})
+target_link_libraries(cpuid_handler PRIVATE unicorn ${UNICORN_LIB})
 target_include_directories(fork_handler PRIVATE ${ARION_INCLUDE_DIR}/arion)
 
 add_executable(target target.c)

--- a/examples/SpeedTester/CMakeLists.txt
+++ b/examples/SpeedTester/CMakeLists.txt
@@ -9,5 +9,5 @@ find_path(ARION_INCLUDE_DIR arion/arion.hpp)
 add_executable(speed_tester speed_tester.cpp)
 
 target_link_libraries(speed_tester PRIVATE ${ARION_LIB})
-target_link_libraries(cpuid_handler PRIVATE unicorn ${UNICORN_LIB})
+target_link_libraries(speed_tester PRIVATE unicorn ${UNICORN_LIB})
 target_include_directories(speed_tester PRIVATE ${ARION_INCLUDE_DIR}/arion)

--- a/examples/SpeedTester/CMakeLists.txt
+++ b/examples/SpeedTester/CMakeLists.txt
@@ -9,4 +9,5 @@ find_path(ARION_INCLUDE_DIR arion/arion.hpp)
 add_executable(speed_tester speed_tester.cpp)
 
 target_link_libraries(speed_tester PRIVATE ${ARION_LIB})
+target_link_libraries(cpuid_handler PRIVATE unicorn ${UNICORN_LIB})
 target_include_directories(speed_tester PRIVATE ${ARION_INCLUDE_DIR}/arion)


### PR DESCRIPTION
- disable lief docs, ... (non used) #9 
- set unicorn/capstone/keystone to build only x86/arm for now #9 
- fix examples DSO missing unicorn linker fail #4 